### PR TITLE
[1차 세미나] 필수 구현 과제

### DIFF
--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/src/main/java/org/sopt/seminar1/Diary.java
+++ b/src/main/java/org/sopt/seminar1/Diary.java
@@ -1,0 +1,19 @@
+package org.sopt.seminar1;
+
+public class Diary {
+    private Long id;
+    private final String body;
+
+    public Diary(Long id, String body) {
+        this.id = id;
+        this.body = body;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getBody() {
+        return body;
+    }
+}

--- a/src/main/java/org/sopt/seminar1/DiaryController.java
+++ b/src/main/java/org/sopt/seminar1/DiaryController.java
@@ -1,0 +1,40 @@
+package org.sopt.seminar1;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DiaryController {
+    private Status status = Status.READY;
+    private final DiaryService diaryService = new DiaryService();
+    Status getStatus() {
+        return status;
+    }
+    void boot() {
+        this.status = Status.RUNNING;
+    }
+    void finish() {
+        this.status = Status.FINISHED;
+    }
+    // APIS
+    final List<Diary> getList() {
+        return diaryService.getDiaryList();
+    }
+    final void post(final String body) {
+        //입력받은 body 저장하기
+        diaryService.writeDairy(body);
+
+    }
+    final void delete(final String id) {
+
+    }
+    final void patch(final String id, final String body) {
+
+    }
+    enum Status {
+        READY,
+        RUNNING,
+        FINISHED,
+        ERROR,
+    }
+}

--- a/src/main/java/org/sopt/seminar1/DiaryController.java
+++ b/src/main/java/org/sopt/seminar1/DiaryController.java
@@ -4,6 +4,7 @@ package org.sopt.seminar1;
 import java.util.ArrayList;
 import java.util.List;
 
+
 public class DiaryController {
     private Status status = Status.READY;
     private final DiaryService diaryService = new DiaryService();
@@ -21,16 +22,19 @@ public class DiaryController {
         return diaryService.getDiaryList();
     }
     final void post(final String body) {
+
         //입력받은 body 저장하기
         diaryService.writeDairy(body);
 
     }
     final void delete(final String id) {
-
+        diaryService.deleteDiary(Long.parseLong(id));
     }
     final void patch(final String id, final String body) {
-
+        //입력받은 id(index에 있다면)의 body 수정하기
+        diaryService.patchDiary(Long.parseLong(id), body);
     }
+
     enum Status {
         READY,
         RUNNING,

--- a/src/main/java/org/sopt/seminar1/DiaryController.java
+++ b/src/main/java/org/sopt/seminar1/DiaryController.java
@@ -1,6 +1,7 @@
 package org.sopt.seminar1;
 
 import org.sopt.seminar1.Main.UI.BodyLengthException;
+import org.sopt.seminar1.Main.UI.InvalidInputException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,8 +23,8 @@ public class DiaryController {
         return diaryService.getDiaryList();
     }
     final void post(final String body) {
-        //글자수 제한 검증
-        validateLength(body);
+        //입력 글자수 제한 검증
+        validateInput(body);
         //입력받은 body 저장하기
         diaryService.writeDairy(body);
 
@@ -33,17 +34,30 @@ public class DiaryController {
     }
     final void patch(final String id, final String body) {
         //입력받은 id(index에 있다면)의 body 수정하기
-        //글자 수 제한 검증
-        validateLength(body);
+
+
+        //입력 글자 수 제한 검증
+        validateInput(body);
         diaryService.patchDiary(Long.parseLong(id), body);
     }
 
-    final void validateLength(String body) {
+    final void validateInput(String body) {
+        //30자 초과
         if(body.length()>=31) {
             System.out.println(body.length()+"자");
             throw new BodyLengthException();
         }
+        //입력 x
+        if(body.trim().equals("")) {
+            throw new InvalidInputException();
+        }
     }
+
+    final void validateId(final String id) {
+        //id가 존재 유무 검즘
+
+    }
+
 
     enum Status {
         READY,

--- a/src/main/java/org/sopt/seminar1/DiaryController.java
+++ b/src/main/java/org/sopt/seminar1/DiaryController.java
@@ -1,6 +1,6 @@
 package org.sopt.seminar1;
 
-
+import org.sopt.seminar1.Main.UI.BodyLengthException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,7 +22,8 @@ public class DiaryController {
         return diaryService.getDiaryList();
     }
     final void post(final String body) {
-
+        //글자수 제한 검증
+        validateLength(body);
         //입력받은 body 저장하기
         diaryService.writeDairy(body);
 
@@ -32,7 +33,16 @@ public class DiaryController {
     }
     final void patch(final String id, final String body) {
         //입력받은 id(index에 있다면)의 body 수정하기
+        //글자 수 제한 검증
+        validateLength(body);
         diaryService.patchDiary(Long.parseLong(id), body);
+    }
+
+    final void validateLength(String body) {
+        if(body.length()>=31) {
+            System.out.println(body.length()+"자");
+            throw new BodyLengthException();
+        }
     }
 
     enum Status {

--- a/src/main/java/org/sopt/seminar1/DiaryController.java
+++ b/src/main/java/org/sopt/seminar1/DiaryController.java
@@ -30,15 +30,23 @@ public class DiaryController {
 
     }
     final void delete(final String id) {
-        diaryService.deleteDiary(Long.parseLong(id));
+        try {
+            diaryService.deleteDiary(Long.parseLong(id));
+        } catch (NumberFormatException e) { //입력 id 타입 검증
+            throw new InvalidInputException();
+        }
+
     }
+
     final void patch(final String id, final String body) {
-        //입력받은 id(index에 있다면)의 body 수정하기
+        try {
+            //입력 글자 수 제한 검증
+            validateInput(body);
+            diaryService.patchDiary(Long.parseLong(id), body);
+        } catch (NumberFormatException e) { //입력 id 타입 검증
+            throw new InvalidInputException();
+        }
 
-
-        //입력 글자 수 제한 검증
-        validateInput(body);
-        diaryService.patchDiary(Long.parseLong(id), body);
     }
 
     final void validateInput(String body) {
@@ -48,15 +56,12 @@ public class DiaryController {
             throw new BodyLengthException();
         }
         //입력 x
-        if(body.trim().equals("")) {
+        if(body.trim().isEmpty()) {
             throw new InvalidInputException();
         }
     }
 
-    final void validateId(final String id) {
-        //id가 존재 유무 검즘
 
-    }
 
 
     enum Status {

--- a/src/main/java/org/sopt/seminar1/DiaryRepository.java
+++ b/src/main/java/org/sopt/seminar1/DiaryRepository.java
@@ -60,6 +60,10 @@ public class DiaryRepository {
         storage.remove(id);
     }
 
+    boolean existsById(final Long id) {
+        return storage.containsKey(id);
+    }
+
 
 
 }

--- a/src/main/java/org/sopt/seminar1/DiaryRepository.java
+++ b/src/main/java/org/sopt/seminar1/DiaryRepository.java
@@ -29,7 +29,8 @@ public class DiaryRepository {
         // (2) 저장한 값을 불러오는 반복 구조
         for(long index=1; index <= numbering.longValue(); index++) {
             final String body = storage.get(index);
-
+            
+            //delete될 경우, null이 저장되므로 제외해야 함
             if(body != null) {
                 //(2-1) 불러온 값을 구성한 자료구조로 이관
                 diaryList.add(new Diary(index, body));
@@ -43,7 +44,14 @@ public class DiaryRepository {
 
 
     void update(final Long id, final String body) {
+        //body가 null이면 삭제된 일기 -> update x
+        final String getBody = storage.get(id);
+        if(getBody == null) {
+            return;
+        }
         storage.put(id, body);
+
+
 
     }
 

--- a/src/main/java/org/sopt/seminar1/DiaryRepository.java
+++ b/src/main/java/org/sopt/seminar1/DiaryRepository.java
@@ -1,0 +1,45 @@
+package org.sopt.seminar1;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.lang.Integer.parseInt;
+
+
+public class DiaryRepository {
+    private final Map<Long, String> storage = new ConcurrentHashMap<>();
+    private final AtomicLong numbering = new AtomicLong();
+
+
+    void save(final Diary diary) {
+        //채번 과정
+        final long id = numbering.addAndGet(1);
+;
+        //저장 과정
+        storage.put(id, diary.getBody());
+    }
+
+
+    List<Diary> findAll() {
+        // (1) diary 담을 자료 구조
+        final List<Diary> diaryList = new ArrayList<>();
+
+        // (2) 저장한 값을 불러오는 반복 구조
+        for(long index=1; index <= numbering.longValue(); index++) {
+            final String body = storage.get(index);
+
+            //(2-1) 불러온 값을 구성한 자료구조로 이관
+            diaryList.add(new Diary(index, body));
+        }
+
+        //(3) 불러온 자료구조 응답
+        return diaryList;
+    }
+
+
+
+
+
+}

--- a/src/main/java/org/sopt/seminar1/DiaryRepository.java
+++ b/src/main/java/org/sopt/seminar1/DiaryRepository.java
@@ -16,7 +16,7 @@ public class DiaryRepository {
     void save(final Diary diary) {
         //채번 과정
         final long id = numbering.addAndGet(1);
-;
+
         //저장 과정
         storage.put(id, diary.getBody());
     }
@@ -30,8 +30,11 @@ public class DiaryRepository {
         for(long index=1; index <= numbering.longValue(); index++) {
             final String body = storage.get(index);
 
-            //(2-1) 불러온 값을 구성한 자료구조로 이관
-            diaryList.add(new Diary(index, body));
+            if(body != null) {
+                //(2-1) 불러온 값을 구성한 자료구조로 이관
+                diaryList.add(new Diary(index, body));
+            }
+
         }
 
         //(3) 불러온 자료구조 응답
@@ -39,6 +42,15 @@ public class DiaryRepository {
     }
 
 
+    void update(final Long id, final String body) {
+        storage.put(id, body);
+
+    }
+
+    void delete(final Long id) {
+        //id 검증
+        storage.remove(id);
+    }
 
 
 

--- a/src/main/java/org/sopt/seminar1/DiaryRepository.java
+++ b/src/main/java/org/sopt/seminar1/DiaryRepository.java
@@ -43,7 +43,7 @@ public class DiaryRepository {
     }
 
 
-    void update(final Long id, final String body) {
+    void patch(final Long id, final String body) {
         //body가 null이면 삭제된 일기 -> update x
         final String getBody = storage.get(id);
         if(getBody == null) {

--- a/src/main/java/org/sopt/seminar1/DiaryRepository.java
+++ b/src/main/java/org/sopt/seminar1/DiaryRepository.java
@@ -51,12 +51,9 @@ public class DiaryRepository {
         }
         storage.put(id, body);
 
-
-
     }
 
     void delete(final Long id) {
-        //id 검증
         storage.remove(id);
     }
 

--- a/src/main/java/org/sopt/seminar1/DiaryService.java
+++ b/src/main/java/org/sopt/seminar1/DiaryService.java
@@ -7,13 +7,20 @@ public class DiaryService {
     private final DiaryRepository diaryRepository = new DiaryRepository();
 
     void writeDairy(final String body) {
-        if(body.length()<31) {
             final Diary diary = new Diary(null, body);
             diaryRepository.save(diary);
-        }
     }
     List<Diary> getDiaryList() {
         return diaryRepository.findAll();
+    }
+
+    void patchDiary(final Long id, final String body) {
+        diaryRepository.update(id, body);
+    }
+
+    void deleteDiary(final Long id) {
+
+        diaryRepository.delete(id);
     }
 
 

--- a/src/main/java/org/sopt/seminar1/DiaryService.java
+++ b/src/main/java/org/sopt/seminar1/DiaryService.java
@@ -1,5 +1,5 @@
 package org.sopt.seminar1;
-
+import org.sopt.seminar1.Main.UI.IdNotExistException;
 
 import java.util.List;
 
@@ -15,12 +15,21 @@ public class DiaryService {
     }
 
     void patchDiary(final Long id, final String body) {
-        diaryRepository.update(id, body);
+        if(diaryRepository.existsById(id)) {
+            diaryRepository.update(id, body);
+        } else {
+            throw new IdNotExistException();
+        }
+
     }
 
     void deleteDiary(final Long id) {
+        if(diaryRepository.existsById(id)) {
+            diaryRepository.delete(id);
+        } else {
+            throw new IdNotExistException();
+        }
 
-        diaryRepository.delete(id);
     }
 
 

--- a/src/main/java/org/sopt/seminar1/DiaryService.java
+++ b/src/main/java/org/sopt/seminar1/DiaryService.java
@@ -15,6 +15,7 @@ public class DiaryService {
     }
 
     void patchDiary(final Long id, final String body) {
+        //입력받은 id가 index에 존재하는지 확인
         if(diaryRepository.existsById(id)) {
             diaryRepository.update(id, body);
         } else {
@@ -24,6 +25,7 @@ public class DiaryService {
     }
 
     void deleteDiary(final Long id) {
+        //입력받은 id가 index에 존재하는지 확인
         if(diaryRepository.existsById(id)) {
             diaryRepository.delete(id);
         } else {

--- a/src/main/java/org/sopt/seminar1/DiaryService.java
+++ b/src/main/java/org/sopt/seminar1/DiaryService.java
@@ -1,0 +1,21 @@
+package org.sopt.seminar1;
+
+
+import java.util.List;
+
+public class DiaryService {
+    private final DiaryRepository diaryRepository = new DiaryRepository();
+
+    void writeDairy(final String body) {
+        if(body.length()<31) {
+            final Diary diary = new Diary(null, body);
+            diaryRepository.save(diary);
+        }
+    }
+    List<Diary> getDiaryList() {
+        return diaryRepository.findAll();
+    }
+
+
+
+}

--- a/src/main/java/org/sopt/seminar1/DiaryService.java
+++ b/src/main/java/org/sopt/seminar1/DiaryService.java
@@ -17,7 +17,7 @@ public class DiaryService {
     void patchDiary(final Long id, final String body) {
         //입력받은 id가 index에 존재하는지 확인
         if(diaryRepository.existsById(id)) {
-            diaryRepository.update(id, body);
+            diaryRepository.patch(id, body);
         } else {
             throw new IdNotExistException();
         }

--- a/src/main/java/org/sopt/seminar1/Main.java
+++ b/src/main/java/org/sopt/seminar1/Main.java
@@ -1,0 +1,143 @@
+package org.sopt.seminar1;
+
+
+
+import java.io.*;
+public class Main {
+    public static void main(String[] args) {
+        final UI ui;
+        try {
+            ui = new DiaryUI(new DiaryController());
+            ui.runRepeatedly();
+        } catch (Throwable t) {
+        }
+    }
+    interface UI {
+        void runRepeatedly() throws IOException;
+        class UIException extends RuntimeException {
+        }
+        class InvalidInputException extends UIException {
+        }
+    }
+    static class DiaryUI implements UI {
+        private final DiaryController server;
+        private String selected;
+        public DiaryUI(DiaryController server) throws IOException {
+            this.server = server;
+            server.boot();
+            ConsoleIO.printLine(getStartMessage());
+        }
+        public void runRepeatedly() throws IOException {
+            do {
+                if (onMenu()) {
+                    ConsoleIO.printLine("");
+                    ConsoleIO.printLine(getMenu());
+                    selected = ConsoleIO.readLine().trim().toUpperCase();
+                }
+                try {
+                    run();
+                } catch (InvalidInputException e) {
+                    ConsoleIO.printLine("잘못된 값을 입력하였습니다.");
+                }
+                if (isFinished()) {
+                    ConsoleIO.printLine(getFinishMessage());
+                    break;
+                }
+                selected = null;
+            } while (isRunning());
+        }
+        private void run() throws IOException {
+            switch (server.getStatus()) {
+                case READY, FINISHED, ERROR -> throw new UIException();
+                case RUNNING -> {
+                    switch (selected) {
+                        case "GET" -> {
+                            server.getList().forEach(diary -> {
+                                try {
+                                    ConsoleIO.printLine(diary.getId()+" : "+diary.getBody());
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+                        }
+                        case "POST" -> {
+                            ConsoleIO.printLine("한 줄 일기를 작성해주세요!");
+                            final String input = ConsoleIO.readLine();
+                            server.post(input);
+                        }
+                        case "DELETE" -> {
+                            ConsoleIO.printLine("삭제할 id 를 입력하세요!");
+                            final String input = ConsoleIO.readLine();
+                            server.delete(input);
+                        }
+                        case "PATCH" -> {
+                            ConsoleIO.printLine("수정할 id 를 입력하세요!");
+                            final String inputId = ConsoleIO.readLine();
+                            ConsoleIO.printLine("수정 body 를 입력하세요!");
+                            final String inputBody = ConsoleIO.readLine();
+                            server.patch(inputId, inputBody);
+                        }
+                        case "FINISH" -> {
+                            server.finish();
+                        }
+                        default -> {
+                            throw new InvalidInputException();
+                        }
+                    }
+                }
+            }
+        }
+        private boolean isRunning() {
+            return server.getStatus() == DiaryController.Status.RUNNING;
+        }
+        private boolean isFinished() {
+            return server.getStatus() == DiaryController.Status.FINISHED;
+        }
+        private boolean onMenu() {
+            return selected == null;
+        }
+        private String getMenu() {
+            return """
+                    ============================
+                    - GET : 일기 불러오기
+                    - POST : 일기 작성하기
+                    - DELETE : 일기 제거하기
+                    - PATCH : 일기 수정하기
+                    """;
+        }
+        private String getStartMessage() {
+            return "시작합니다 :)";
+        }
+        private String getFinishMessage() {
+            return "종료됩니다 :)";
+        }
+    }
+    // not thread safe
+    private static class ConsoleIO {
+        private final static BufferedWriter bufferedWriter = new BufferedWriter(new OutputStreamWriter(System.out));
+        private final static BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(System.in));
+        private final static StringBuilder sb = new StringBuilder();
+        public static void printLine(final String toPrint) throws IOException {
+            if (toPrint == null) {
+                throw new IllegalArgumentException("console can not print null");
+            }
+            appendLine(toPrint);
+            print();
+            clearStringBuilder();
+        }
+        public static String readLine() throws IOException {
+            return bufferedReader.readLine();
+        }
+        private static void appendLine(final String toPrint) {
+            sb.append(toPrint);
+            sb.append("\n");
+        }
+        private static void print() throws IOException {
+            bufferedWriter.write(sb.toString());
+            bufferedWriter.flush();
+        }
+        private static void clearStringBuilder() {
+            sb.setLength(0);
+        }
+    }
+}

--- a/src/main/java/org/sopt/seminar1/Main.java
+++ b/src/main/java/org/sopt/seminar1/Main.java
@@ -18,6 +18,9 @@ public class Main {
         }
         class InvalidInputException extends UIException {
         }
+        class BodyLengthException extends UIException {
+
+        }
     }
     static class DiaryUI implements UI {
         private final DiaryController server;
@@ -38,6 +41,8 @@ public class Main {
                     run();
                 } catch (InvalidInputException e) {
                     ConsoleIO.printLine("잘못된 값을 입력하였습니다.");
+                } catch(BodyLengthException e) {
+                    ConsoleIO.printLine("글자 수를 30자 내로 작성해 주세요.");
                 }
                 if (isFinished()) {
                     ConsoleIO.printLine(getFinishMessage());

--- a/src/main/java/org/sopt/seminar1/Main.java
+++ b/src/main/java/org/sopt/seminar1/Main.java
@@ -19,7 +19,8 @@ public class Main {
         class InvalidInputException extends UIException {
         }
         class BodyLengthException extends UIException {
-
+        }
+        class IdNotExistException extends UIException {
         }
     }
     static class DiaryUI implements UI {
@@ -43,6 +44,8 @@ public class Main {
                     ConsoleIO.printLine("잘못된 값을 입력하였습니다.");
                 } catch(BodyLengthException e) {
                     ConsoleIO.printLine("글자 수를 30자 내로 작성해 주세요.");
+                } catch(IdNotExistException e) {
+                    ConsoleIO.printLine("존재하지 않는 Id입니다.");
                 }
                 if (isFinished()) {
                     ConsoleIO.printLine(getFinishMessage());


### PR DESCRIPTION
> # 📌 TO DO

- [x] [GET] 일기 조회 기능
- [x] [POST] 일기 작성 기능, 글자 수 30자 제한
- [x] [DELETE] 일기 삭제 기능
- [x] [PATCH] 일기 수정 기능


> ## ☑️ 구현 결과


| [GET] 일기 조회 기능 | [POST] 일기 작성 기능 | [POST] 글자수 30자 제한 |
|     :---:      |     :---:      |     :---:      |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/ea2a66b6-f611-4e4d-b212-9f0767192a1f">  | <img width="250" alt="image" src="https://github.com/user-attachments/assets/4fae59f8-27fd-4996-a05f-1c73edddca1c">| <img width="250" alt="image" src="https://github.com/user-attachments/assets/6f3baecd-0ba3-4308-a160-c40168b57333">|

| [DELETE] 일기 삭제 기능 | [PATCH] 일기 수정기능 |
|     :---:      |     :---:      |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/b01a4350-213b-493c-bd3c-49593e3f739a">  | <img width="250" alt="image" src="https://github.com/user-attachments/assets/fc96b51c-09d3-459a-993a-48edfa7d8cc2"> |

> ## ☑️ 코드 구현

- delete된 일기의 body에는 null이 저장되므로, 일기 목록을 조회할 때 body가 null인 경우를 제외하고 조회할 수 있도록 `findAll()` 코드 수정하였습니다.

`DiaryRepository.java`
```java
//delete될 경우, null이 저장되므로 제외해야 함
            if(body != null) {
                //(2-1) 불러온 값을 구성한 자료구조로 이관
                diaryList.add(new Diary(index, body));
            }
``` 

- `post`와 `patch` 기능 중 body를 입력받을 때 아무것도 입력하지 않는 경우에는 `InvalidInputException`을, 30자를 초과하는 경우에는 `BodyLengthException`으로 예외 처리를 해주었습니다. Main에 UIException을 상속 받는 커스텀 에러 `BodyLengthException`를 추가했습니다.

`DiaryController.java`
```java
final void validateInput(String body) {
        //30자 초과
        if(body.length()>=31) {
            System.out.println(body.length()+"자");
            throw new BodyLengthException();
        }
        //입력 x
        if(body.trim().isEmpty()) {
            throw new InvalidInputException();
        }
    }
``` 

- `ConcurrentHashMap`의 `containsKey(id)`을 통해 맵에 `id`값이 있으면 `true`, 없으면 `false`를 반환합니다. 이 값이 `true`이면 `patchDiary()`와 `deleteDiary()`에서 각각 `patch()`와 `delete()`를 실행합니다. `false`인 경우, `IdNotExistException`으로 예외 처리를 해주었습니다.  Main에 UIException을 상속 받는 커스텀 에러 `IdNotExistException`를 추가했습니다.
`DiaryRepository.java`
```java
boolean existsById(final Long id) {
        return storage.containsKey(id);
    }
``` 
`DiaryService.java`
```java
void patchDiary(final Long id, final String body) {
        //입력받은 id가 index에 존재하는지 확인
        if(diaryRepository.existsById(id)) {
            diaryRepository.patch(id, body);
        } else {
            throw new IdNotExistException();
        }

    }

    void deleteDiary(final Long id) {
        //입력받은 id가 index에 존재하는지 확인
        if(diaryRepository.existsById(id)) {
            diaryRepository.delete(id);
        } else {
            throw new IdNotExistException();
        }

    }
``` 


- `delete()`와 `patch()`에서 `try - catch문`을 통해 입력받은 id 타입에 대한 검증을 수행합니다. `id`값에 문자가 포함된 경우에는 `InvalidInputException`으로 예외 처리를 해주었습니다.

`DiaryController.java`
```java
final void delete(final String id) {
        try {
            diaryService.deleteDiary(Long.parseLong(id));
        } catch (NumberFormatException e) { //입력 id 타입 검증
            throw new InvalidInputException();
        }

    }

    final void patch(final String id, final String body) {
        try {
            //입력 글자 수 제한 검증
            validateInput(body);
            diaryService.patchDiary(Long.parseLong(id), body);
        } catch (NumberFormatException e) { //입력 id 타입 검증
            throw new InvalidInputException();
        }

    }
``` 

> ## ☑️ 생각해볼 점
- 입력받은 id가 index에 존재하는지와 타입 검증이 delete()와 patch()에서 중복되고 있는데, 하나의 템플릿?을 만들어서 중복을 최소화할 수 있는 방법은 없을까,,? 생각해보면 좋을 것 같습니다.